### PR TITLE
update membership check, closes #1

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -30,7 +30,7 @@ current active member.
 
 Each *official* subproject in Jupyter gets a single [Software Steering Council
 Representative](https://jupyter.org/governance/software_steering_council.html#software-steering-council).
-JupyterLab's representative is elected by the members. This representative
+Jupyter Foundations and Standards Subproject's representative is elected by the members. This representative
 *should* be re-elected every year (in January).
 
 In 2023, the current representative is Paul Ivanov.

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,7 +1,7 @@
 # Current Jupyter Foundations and Standards Council members
 
 This page lists (alphabetically) the officially named Jupyter Foundations and Standards
-Council.
+Council. It was last updated in January 2024.
 
 ## Active members
 

--- a/docs/team/council.yml
+++ b/docs/team/council.yml
@@ -11,73 +11,73 @@
   handle: "@damianavila"
   affiliation: 2i2c
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Kevin Bates
   handle: "@kevin-bates"
   affiliation: IBM
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Matthias Bussonnier
   handle: "@Carreau"
   affiliation: Quansight Labs
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Sylvain Corlay
   handle: "@SylvainCorlay"
   affiliation: QuantStack
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Jason Grout
   handle: "@jasongrout"
   affiliation: Databricks
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Paul Ivanov
   handle: "@ivanov"
   affiliation: Jupyter
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Kyle Kelley
   handle: "@rgbkrk"
   affiliation: Noteable
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Min Ragan-Kelley
   handle: "@minrk"
   affiliation: Simula Research Lab
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Johan Mabille
   handle: "@JohanMabille"
   affiliation: QuantStack
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Matthew Seal
   handle: "@mseal"
   affiliation: Noteable
-  team: active
-  last-check-in: 2023-12
+  team: inactive
+  last-check-in: 2024-12
 
 - name: Steven Silvester
   handle: "@blink1073"
   affiliation: MongoDB
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 - name: Carol Willing
   handle: "@willingc"
   affiliation: Willing Consulting
   team: active
-  last-check-in: 2023-12
+  last-check-in: 2024-12
 
 
 

--- a/docs/team/council.yml
+++ b/docs/team/council.yml
@@ -1,4 +1,4 @@
-# Active Council members
+# Council members
 # Use ALPHABETICAL (BY LAST NAME) ORDER please :-)
 
 # - name: Joe/Jane
@@ -11,74 +11,72 @@
   handle: "@damianavila"
   affiliation: 2i2c
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Kevin Bates
   handle: "@kevin-bates"
   affiliation: IBM
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Matthias Bussonnier
   handle: "@Carreau"
   affiliation: Quansight Labs
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Sylvain Corlay
   handle: "@SylvainCorlay"
   affiliation: QuantStack
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Jason Grout
   handle: "@jasongrout"
   affiliation: Databricks
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Paul Ivanov
   handle: "@ivanov"
   affiliation: Jupyter
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Kyle Kelley
   handle: "@rgbkrk"
   affiliation: Noteable
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Min Ragan-Kelley
   handle: "@minrk"
   affiliation: Simula Research Lab
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Johan Mabille
   handle: "@JohanMabille"
   affiliation: QuantStack
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Matthew Seal
   handle: "@mseal"
   affiliation: Noteable
   team: inactive
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Steven Silvester
   handle: "@blink1073"
   affiliation: MongoDB
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 - name: Carol Willing
   handle: "@willingc"
   affiliation: Willing Consulting
   team: active
-  last-check-in: 2024-12
+  last-check-in: 2024-01
 
 
-
-# Inactive council members at the end, also alphabetical


### PR DESCRIPTION
Reflect current membership based on check #1.

As we move some members to `inactive` status based on response (or lack thereof) in the membership check, I want to thank @MSeal for helping steer the foundations and standards subprojects in their inaugural form.

Reminder that 
> Inactive council members are (temporarily or not) pausing their active participation in the Jupyter Foundations and Standards community. They can reactivate themselves at any point in the future; it does not require a nomination by a current active member.